### PR TITLE
👷‍♂️ ci(workflow): add permissions block to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added a permissions block to the GitHub Actions CI workflow to explicitly set read access for contents. This follows security best practices by restricting the default permissions granted to the workflow, reducing the potential attack surface.