### PR TITLE
💚 ci: drop Node 20.x and add Node 26.x to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Update GitHub Actions CI matrix to test against current LTS versions. Node 20.x reached end-of-life, so remove it and add Node 26.x.