### PR TITLE
🔧 chore(deps): allow scripts for specific npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
   },
   "overrides": {
     "glob": "^11.1.0"
+  },
+  "allowScripts": {
+    "re2@1.26.1": true,
+    "unrs-resolver@1.11.1": true
   }
 }


### PR DESCRIPTION
Enable postinstall scripts for re2 and unrs-resolver by setting allowScripts to true in package.json.